### PR TITLE
Add CLI dashboard with GTFS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Déploiement :
 - GitHub Pages pour l'affichage HTML/CSS/JS
 
 Actualisation toutes les 60 secondes.
+
+## Utilisation en ligne de commande
+
+Un tableau de bord console est fourni via `vhp3_dashboard.py`. Pour l'exécuter avec les données GTFS incluses :
+
+```bash
+python vhp3_dashboard.py
+```
+
+Le script tente d'interroger l'API temps réel via le proxy Cloudflare. En cas d'échec, il se rabat sur les horaires prévus depuis `data/gtfs/`.

--- a/data/gtfs/agency.txt
+++ b/data/gtfs/agency.txt
@@ -1,0 +1,2 @@
+agency_id,agency_name,agency_url,agency_timezone
+IDFM,Ile-de-France Mobilites,https://www.iledefrance-mobilites.fr,Europe/Paris

--- a/data/gtfs/calendar.txt
+++ b/data/gtfs/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+WD,1,1,1,1,1,0,0,20240101,20241231

--- a/data/gtfs/routes.txt
+++ b/data/gtfs/routes.txt
@@ -1,0 +1,4 @@
+route_id,agency_id,route_short_name,route_long_name,route_type
+RER_A,IDFM,RER A,RER A,2
+BUS_77,IDFM,77,Bus 77,3
+BUS_201,IDFM,201,Bus 201,3

--- a/data/gtfs/stop_times.txt
+++ b/data/gtfs/stop_times.txt
@@ -1,0 +1,4 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence
+RER_A_trip1,10:00:00,10:00:00,stop_rer,1
+BUS77_trip1,10:15:00,10:15:00,stop_bus77,1
+BUS201_trip1,10:20:00,10:20:00,stop_bus201,1

--- a/data/gtfs/stops.txt
+++ b/data/gtfs/stops.txt
@@ -1,0 +1,4 @@
+stop_id,stop_name,stop_lat,stop_lon
+stop_rer,Joinville-le-Pont,48.821,2.457
+stop_bus77,Hippodrome de Vincennes,48.836,2.435
+stop_bus201,Ecole du Breuil,48.833,2.447

--- a/data/gtfs/trips.txt
+++ b/data/gtfs/trips.txt
@@ -1,0 +1,4 @@
+route_id,service_id,trip_id,trip_headsign
+RER_A,WD,RER_A_trip1,Paris
+BUS_77,WD,BUS77_trip1,Vincennes
+BUS_201,WD,BUS201_trip1,Ecole du Breuil

--- a/vhp3_dashboard.py
+++ b/vhp3_dashboard.py
@@ -1,0 +1,131 @@
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+from typing import List, Dict, Optional
+
+import requests
+
+PROXY_URL = "https://transportvhp.hippodrome-proxy42.workers.dev/?ref="
+POINTS = {
+    "rer": "STIF:StopPoint:Q:43135:",
+    "bus77": "STIF:StopPoint:Q:463641:",
+    "bus201": "STIF:StopPoint:Q:463644:"
+}
+
+# Map API stop references to GTFS stop identifiers
+REF_TO_GTFS = {
+    "STIF:StopPoint:Q:43135:": "stop_rer",
+    "STIF:StopPoint:Q:463641:": "stop_bus77",
+    "STIF:StopPoint:Q:463644:": "stop_bus201",
+}
+
+class GTFS:
+    def __init__(self, path: str):
+        self.path = path
+        self.routes: Dict[str, Dict[str, str]] = {}
+        self.trips: Dict[str, Dict[str, str]] = {}
+        self.stop_times: List[Dict[str, str]] = []
+        self.calendar: Dict[str, Dict[str, str]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        def read(name):
+            fp = os.path.join(self.path, name)
+            with open(fp, newline='') as f:
+                return list(csv.DictReader(f))
+
+        for r in read('routes.txt'):
+            self.routes[r['route_id']] = r
+        for t in read('trips.txt'):
+            self.trips[t['trip_id']] = t
+        self.stop_times = read('stop_times.txt')
+        for cal in read('calendar.txt'):
+            self.calendar[cal['service_id']] = cal
+
+    def _service_active(self, service: Dict[str, str], date: dt.date) -> bool:
+        start = dt.datetime.strptime(service['start_date'], '%Y%m%d').date()
+        end = dt.datetime.strptime(service['end_date'], '%Y%m%d').date()
+        if not (start <= date <= end):
+            return False
+        weekday = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'][date.weekday()]
+        return service.get(weekday, '0') == '1'
+
+    def next_departures(self, stop_id: str, date_time: dt.datetime, limit: int = 3) -> List[Dict[str, str]]:
+        results = []
+        active_services = {sid for sid, srv in self.calendar.items() if self._service_active(srv, date_time.date())}
+
+        for st in self.stop_times:
+            if st['stop_id'] != stop_id:
+                continue
+            trip = self.trips.get(st['trip_id'])
+            if not trip or trip['service_id'] not in active_services:
+                continue
+            # Parse time in HH:MM:SS possibly >24h
+            h, m, s = map(int, st['departure_time'].split(':'))
+            dep_time = (date_time.replace(hour=0, minute=0, second=0, microsecond=0)
+                        + dt.timedelta(hours=h, minutes=m, seconds=s))
+            if dep_time >= date_time:
+                route = self.routes.get(trip['route_id'], {})
+                results.append({
+                    'line': route.get('route_short_name', trip['route_id']),
+                    'direction': trip.get('trip_headsign', ''),
+                    'time': dep_time
+                })
+        results.sort(key=lambda x: x['time'])
+        return results[:limit]
+
+def fetch_realtime(ref: str) -> Optional[List[Dict[str, str]]]:
+    url = PROXY_URL + requests.utils.quote(ref, safe='')
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        visits = (data.get('Siri', {})
+                     .get('ServiceDelivery', {})
+                     .get('StopMonitoringDelivery', [{}])[0]
+                     .get('MonitoredStopVisit', []))
+        results = []
+        for visit in visits:
+            mvj = visit.get('MonitoredVehicleJourney', {})
+            call = mvj.get('MonitoredCall', {})
+            t = call.get('ExpectedArrivalTime')
+            if t:
+                try:
+                    dt_obj = dt.datetime.fromisoformat(t)
+                except ValueError:
+                    continue
+                results.append({
+                    'line': mvj.get('LineRef', ''),
+                    'direction': mvj.get('DirectionName', ''),
+                    'time': dt_obj
+                })
+        return results if results else None
+    except Exception:
+        return None
+
+def main():
+    parser = argparse.ArgumentParser(description="Display upcoming departures for VHP3")
+    parser.add_argument('--gtfs', default='data/gtfs', help='Path to GTFS directory')
+    args = parser.parse_args()
+
+    gtfs = GTFS(args.gtfs)
+    now = dt.datetime.now()
+    for key, ref in POINTS.items():
+        print(f"\n=== {key.upper()} ===")
+        realtime = fetch_realtime(ref)
+        if realtime:
+            departures = realtime
+            print("Real-time data:")
+        else:
+            stop_id = REF_TO_GTFS.get(ref)
+            departures = gtfs.next_departures(stop_id, now)
+            print("Using GTFS schedule:")
+        for dep in departures:
+            time_str = dep['time'].strftime('%H:%M')
+            direction = dep.get('direction', '')
+            print(f"{dep['line']} -> {direction} at {time_str}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `vhp3_dashboard.py` for real-time departures with GTFS fallback
- include minimal GTFS schedule in `data/gtfs`
- document command-line usage in `README`

## Testing
- `pip install requests --quiet`
- `python vhp3_dashboard.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68612ce4f5708333bf2474a3a48b63c1