### PR TITLE
Add GTFS fallback dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Déploiement :
 - GitHub Pages pour l'affichage HTML/CSS/JS
 
 Actualisation toutes les 60 secondes.
+
+## Mise à jour du jeu de données GTFS
+
+Le script `vhp3_dashboard.py` charge les fichiers GTFS placés dans `data/gtfs/` pour assurer un repli quand l'appel temps réel échoue. Pour mettre à jour ces informations :
+
+1. Télécharger le dernier jeu de données depuis [Île‑de‑France Mobilités](https://data.iledefrance-mobilites.fr/explore/dataset/offre-horaire-tc-idfm-files/information/).
+2. Extraire les fichiers `stops.txt`, `stop_times.txt`, `trips.txt`, `routes.txt` et `calendar.txt`.
+3. Remplacer les fichiers correspondants dans `data/gtfs/` en conservant les mêmes noms.
+
+Le script pourra ensuite utiliser les nouveaux horaires en cas d'indisponibilité de l'API temps réel.

--- a/data/gtfs/calendar.txt
+++ b/data/gtfs/calendar.txt
@@ -1,0 +1,2 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+WKD,1,1,1,1,1,0,0,20240601,20241231

--- a/data/gtfs/routes.txt
+++ b/data/gtfs/routes.txt
@@ -1,0 +1,4 @@
+route_id,route_short_name,route_long_name
+RERA,RER A,RER A
+77,77,Bus 77
+201,201,Bus 201

--- a/data/gtfs/stop_times.txt
+++ b/data/gtfs/stop_times.txt
@@ -1,0 +1,4 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence
+RERA1,07:30:00,07:30:00,STIF:StopPoint:Q:43135:,1
+TRIP77A,07:35:00,07:35:00,STIF:StopPoint:Q:463641:,1
+TRIP201A,07:40:00,07:40:00,STIF:StopPoint:Q:463644:,1

--- a/data/gtfs/stops.txt
+++ b/data/gtfs/stops.txt
@@ -1,0 +1,4 @@
+stop_id,stop_name
+STIF:StopPoint:Q:43135:,Joinville-le-Pont
+STIF:StopPoint:Q:463641:,Hippodrome de Vincennes
+STIF:StopPoint:Q:463644:,Ecole du Breuil

--- a/data/gtfs/trips.txt
+++ b/data/gtfs/trips.txt
@@ -1,0 +1,4 @@
+route_id,service_id,trip_id,trip_headsign
+RERA,WKD,RERA1,Paris
+77,WKD,TRIP77A,Gare de Joinville
+201,WKD,TRIP201A,Ecole du Breuil

--- a/vhp3_dashboard.py
+++ b/vhp3_dashboard.py
@@ -1,0 +1,111 @@
+import csv
+import datetime as dt
+from pathlib import Path
+import requests
+
+GTFS_DIR = Path(__file__).resolve().parent / "data" / "gtfs"
+
+class GTFS:
+    def __init__(self, path: Path):
+        self.path = path
+        self.stops = {}
+        self.routes = {}
+        self.trips = {}
+        self.calendar = {}
+        self.stop_times = []
+        self._load()
+
+    def _load(self):
+        self.stops = {r["stop_id"]: r for r in self._read_csv("stops.txt")}
+        self.routes = {r["route_id"]: r for r in self._read_csv("routes.txt")}
+        self.trips = {r["trip_id"]: r for r in self._read_csv("trips.txt")}
+        self.calendar = {r["service_id"]: r for r in self._read_csv("calendar.txt")}
+        self.stop_times = list(self._read_csv("stop_times.txt"))
+
+    def _read_csv(self, name):
+        with open(self.path / name, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                yield {k: v.strip() for k, v in row.items()}
+
+    def service_active(self, service_id: str, date: dt.date) -> bool:
+        info = self.calendar.get(service_id)
+        if not info:
+            return False
+        weekday = date.strftime("%A").lower()
+        if info.get(weekday) != "1":
+            return False
+        start = dt.datetime.strptime(info["start_date"], "%Y%m%d").date()
+        end = dt.datetime.strptime(info["end_date"], "%Y%m%d").date()
+        return start <= date <= end
+
+    def next_departures(self, stop_id: str, now: dt.datetime | None = None, limit: int = 3):
+        now = now or dt.datetime.now()
+        upcoming = []
+        for st in self.stop_times:
+            if st["stop_id"] != stop_id:
+                continue
+            trip = self.trips.get(st["trip_id"])
+            if not trip:
+                continue
+            if not self.service_active(trip["service_id"], now.date()):
+                continue
+            dep_time = dt.datetime.strptime(st["departure_time"], "%H:%M:%S").time()
+            dep = dt.datetime.combine(now.date(), dep_time)
+            if dep < now:
+                continue
+            route = self.routes.get(trip["route_id"], {})
+            upcoming.append({
+                "line": route.get("route_short_name", ""),
+                "headsign": trip.get("trip_headsign", ""),
+                "time": dep
+            })
+        upcoming.sort(key=lambda x: x["time"])
+        return upcoming[:limit]
+
+def fetch_real_time(stop_ref: str):
+    url = f"https://transportvhp.hippodrome-proxy42.workers.dev/?ref={stop_ref}"
+    resp = requests.get(url, timeout=5)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def display_departures(stop_ref: str, gtfs: GTFS):
+    try:
+        data = fetch_real_time(stop_ref)
+        visits = (
+            data.get("Siri", {})
+            .get("ServiceDelivery", {})
+            .get("StopMonitoringDelivery", [{}])[0]
+            .get("MonitoredStopVisit", [])
+        )
+        if not visits:
+            raise ValueError("no real-time data")
+        for v in visits:
+            mvj = v.get("MonitoredVehicleJourney", {})
+            call = mvj.get("MonitoredCall", {})
+            print(
+                f"{mvj.get('LineRef', '')} {mvj.get('DirectionName', '')} {call.get('ExpectedArrivalTime', '')}"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"Real-time unavailable ({exc}); using GTFS schedule.")
+        for dep in gtfs.next_departures(stop_ref):
+            print(
+                f"{dep['line']} {dep['headsign']} {dep['time'].strftime('%H:%M')}"
+            )
+
+
+def main():
+    gtfs = GTFS(GTFS_DIR)
+    for ref in [
+        "STIF:StopPoint:Q:43135:",
+        "STIF:StopPoint:Q:463641:",
+        "STIF:StopPoint:Q:463644:",
+    ]:
+        name = gtfs.stops.get(ref, {}).get("stop_name", ref)
+        print("---", name)
+        display_departures(ref, gtfs)
+
+
+if __name__ == "__main__":
+    main()

--- a/vhp3_dashboard.py
+++ b/vhp3_dashboard.py
@@ -64,7 +64,7 @@ class GTFS:
         return upcoming[:limit]
 
 def fetch_real_time(stop_ref: str):
-    url = f"https://transportvhp.hippodrome-proxy42.workers.dev/?ref={stop_ref}"
+    url = f"https://ratp-proxy.hippodrome-proxy42.workers.dev/?url={stop_ref}"
     resp = requests.get(url, timeout=5)
     resp.raise_for_status()
     return resp.json()


### PR DESCRIPTION
## Summary
- provide minimal GTFS files under `data/gtfs`
- add `vhp3_dashboard.py` that fetches real‑time data via proxy and falls back to local GTFS
- document how to update these GTFS files

## Testing
- `pip install requests`
- `python3 vhp3_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68613b202b308333ac939419d8fd0c30